### PR TITLE
Fix: linter default file paths

### DIFF
--- a/src/lint/global-dependencies.ts
+++ b/src/lint/global-dependencies.ts
@@ -9,10 +9,10 @@ const globalIdBlacklist: string[] = [];
 
 const defaultFiles = [
   "resources/src/mediawiki/mediawiki.js",
-  "resources/src/mediawiki.util.js",
+  "resources/src/mediawiki/mediawiki.util.js",
   "resources/src/mediawiki/mediawiki.log.js",
   "resources/src/startup.js",
-  "resources/src/mediawiki.template.js",
+  "resources/src/mediawiki/mediawiki.template.js",
   "resources/src/mediawiki/mediawiki.requestIdleCallback.js",
   "resources/src/mediawiki.language/mediawiki.language.init.js"
 ];

--- a/src/lint/global-dependencies.ts
+++ b/src/lint/global-dependencies.ts
@@ -9,10 +9,11 @@ const globalIdBlacklist: string[] = [];
 
 const defaultFiles = [
   "resources/src/mediawiki/mediawiki.js",
-  "resources/src/mediawiki/mediawiki.util.js",
+  "resources/src/mediawiki/mediawiki.base.js",
+  "resources/src/mediawiki.util.js",
   "resources/src/mediawiki/mediawiki.log.js",
   "resources/src/startup.js",
-  "resources/src/mediawiki/mediawiki.template.js",
+  "resources/src/mediawiki.template.js",
   "resources/src/mediawiki/mediawiki.requestIdleCallback.js",
   "resources/src/mediawiki.language/mediawiki.language.init.js"
 ];


### PR DESCRIPTION
The MediaWiki default dependency file paths have changed. Update them to
the latest structure of the tree.

Bug: T197093